### PR TITLE
map page to track

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,10 @@ var Iterable = module.exports = integration('Iterable')
   .channels(['server', 'mobile', 'client'])
   .ensure('settings.apiKey')
   .ensure('message.userId')
+  .mapToTrack(['page'])
+  .option('trackAllPages', true)
+  .option('trackNamedPages', false)
+  .option('trackCategorizedPages', false)
   .mapper(mapper)
   .retries(2);
 


### PR DESCRIPTION
Map all .page calls to track. Don't treat named/categorized in any special way since it sends multiple/duplicate events.