### PR TITLE
Map Pages to Track Events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var Iterable = module.exports = integration('Iterable')
   .channels(['server', 'mobile', 'client'])
   .ensure('settings.apiKey')
   .ensure('message.userId')
+  .mapToTrack(['page'])
   .mapper(mapper)
   .retries(2);
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -195,7 +195,8 @@ exports.page = function(options){
     category: 'Support',
     properties: {
       url: 'https://segment.io/docs',
-      title: 'Analytics.js - Segment.io'
+      title: 'Analytics.js - Segment.io',
+      email: email
     },
     context: {
       ip: '12.212.12.49'

--- a/test/index.js
+++ b/test/index.js
@@ -116,4 +116,44 @@ describe('Iterable', function(){
         .error('cannot POST /api/users/update (401)', done);
     });
   });
+
+  describe('.page()', function(){
+    it('should not track automatically', function (done) {
+      test
+        .set(settings)
+        .page(helpers.page())
+        .requests(0)
+        .end(done);
+    });
+
+    it('should track all pages', function (done) {
+      test
+        .set(settings)
+        .set({ trackAllPages: true })
+        .page(helpers.page())
+        .requests(1)
+        .expects(200)
+        .end(done);
+    });
+
+    it('should track named pages', function (done) {
+      test
+        .set(settings)
+        .set({ trackNamedPages: true })
+        .page(helpers.page())
+        .requests(1)
+        .expects(200)
+        .end(done);
+    });
+
+    it('should track category pages', function (done) {
+      test
+        .set(settings)
+        .set({ trackCategorizedPages: true })
+        .page(helpers.page())
+        .requests(1)
+        .expects(200)
+        .end(done);
+    });
+  });
 });


### PR DESCRIPTION
This will resolve #3 while also adding appropriate tests. This implements `page()` by treating them like track events.

/cc @ndhoule @amillet89 